### PR TITLE
Remove config directory from jest coverage

### DIFF
--- a/configs/jest-preset.json
+++ b/configs/jest-preset.json
@@ -3,6 +3,7 @@
   "collectCoverage": true,
   "collectCoverageFrom": [
     "*/**/*.js",
+    "!config/**/*",
     "!coverage/**/*",
     "!test/**/*"
   ],


### PR DESCRIPTION
This is a directory that holds config information, and not testable code, so there's no benefit in including it in the coverage reports.