### PR TITLE
Add jest testRegex

### DIFF
--- a/configs/jest-preset.json
+++ b/configs/jest-preset.json
@@ -11,5 +11,6 @@
     "<rootDir>"
   ],
   "restoreMocks": true,
-  "testEnvironment": "node"
+  "testEnvironment": "node",
+  "testRegex": "((\\.)(test|spec))\\.js$"
 }


### PR DESCRIPTION
The original `testRegex` value for jest is: `(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$`.

That setting searches for files under the `__tests__` directory, files ending with either `.test.<extension>` or `.spec.<extension>` and files named `test.<extension>` and `spec.<extension>`. It supports the `js` and `jsx` extensions.

A `__tests__` directory goes against common practises on javascript projects, where tests are located either in a `test` directory or under the same directory as their respective component. So we can remove that option.

This project doesn't support jsx yet, so we can also remove that option.

We also don't want to find files named `test.<extension>` or `spec.<extension>`, as it might collide with configuration files such as `config/test.js`, which are not runnable as tests.

Therefore, the new regex is `((\\.)(test|spec))\\.js$`.