### PR TITLE
Update version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is how a `package.json` could look like when making use of these scripts:
     "version": "uphold-scripts version"
   },
   "devDependencies": {
-    "uphold-scripts": "git+ssh://git@github.com/uphold/uphold-scripts#v0.1.0"
+    "uphold-scripts": "git+ssh://git@github.com/uphold/uphold-scripts#v<version>"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
As long as this is a private repo, it's good to show how to pick the latest version in package.json.

In the future, we might want to do this as part of the release commit, to avoid bloating the changelog with PRs like this. Or, better yet, open source this and change our readme to suggest fetching from the npm registry instead of from github.