### PR TITLE
Improve testRegex in jest-preset.json

### DIFF
--- a/configs/jest-preset.json
+++ b/configs/jest-preset.json
@@ -10,5 +10,5 @@
   ],
   "restoreMocks": true,
   "testEnvironment": "node",
-  "testRegex": "((\\.)(test|spec))\\.js$"
+  "testRegex": "\\.test\\.js$"
 }


### PR DESCRIPTION
- Remove the "spec" part of the match, as none of the repos that use (or might use) uphold-scripts uses it
- Remove the unused regex groups