### PR TITLE
Allow passing flags to lint script

### DIFF
--- a/src/uphold-scripts-lint
+++ b/src/uphold-scripts-lint
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-eslint --cache .
+eslint --cache . $@


### PR DESCRIPTION
So that in project were we use the NPM script `"lint": "uphold-scripts lint"` we can pass a `--fix` flag to automatically fix the linting issues.

Especially useful now that we have prettier, which introduces many automatically fixable issues.