### PR TITLE
Improve documentation for published package

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is how a `package.json` could look like when making use of these scripts:
     "version": "uphold-scripts version"
   },
   "devDependencies": {
-    "uphold-scripts": "git+ssh://git@github.com/uphold/uphold-scripts#v0.3.0"
+    "uphold-scripts": "^0.4.0"
   },
   "pre-commit": [
     "lint"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Ricardo Lopes",
   "license": "MIT",
   "precommit.silent": true,
+  "repository": "uphold/uphold-scripts",
   "scripts": {
     "changelog": "uphold-scripts changelog $npm_package_version",
     "release": "uphold-scripts release",


### PR DESCRIPTION
Now that `uphold-scripts` is public and [published on npmjs.com](https://www.npmjs.com/package/uphold-scripts), there are some improvements we can do:
- Update the documentation to suggest installing though npm and not through the direct git repo link
- Add the repo identifier to `package.json` to have a link to it in https://npmjs.com