### PR TITLE
Add configurable parameters to changelog

### DIFF
--- a/src/uphold-scripts-changelog
+++ b/src/uphold-scripts-changelog
@@ -1,3 +1,16 @@
 #!/usr/bin/env sh
 
-github-changelog-generator -f $1 -t v$1 > CHANGELOG.md
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    -f|--future-release) release="-f $2"; shift ;;
+    -t|--future-release-tag) tag="-t $2"; shift ;;
+    -*) arguments=$1; shift ;;
+    *) default=$1; shift ;;
+  esac
+  shift
+done
+
+release=${release:-${default:+"-f v$default"}}
+tag=${tag:-${default:+"-t v$default"}}
+
+github-changelog-generator $release $tag $arguments > CHANGELOG.md


### PR DESCRIPTION
Allows calling `uphold-scripts changelog` and manually specify the tag and release name.

Note that the argument parsing isn't perfect (neither was the original script). There's multiple ways to escape it but I feel that it's good enough for our usual use cases.