### PR TITLE
Remove .ts files from README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This is how a `package.json` could look like when making use of these scripts:
     "lint-staged -q"
   ],
   "lint-staged": {
-    "*.{js,mjs,ts}": ["uphold-scripts lint"]
+    "*.{js,mjs}": ["uphold-scripts lint"]
   }
 }
 ```


### PR DESCRIPTION
Mainly because our eslint-config-uphold does not support TypeScript out of the box.
Once we support it there, we should add `.ts` files back.