### PR TITLE
Remove unnecessary precommit.silent from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "bin": "./src/index.js",
   "author": "Ricardo Lopes",
   "license": "MIT",
-  "precommit.silent": true,
   "repository": "uphold/uphold-scripts",
   "scripts": {
     "changelog": "./src/uphold-scripts-changelog $npm_package_version",


### PR DESCRIPTION
This isn't doing anything as we don't have a `pre-commit` hook on this repo.
If the intention was for repos that use `uphold-scripts` to have no output when running the `pre-commit` hook, they should enable it on the package.json of said repos.