### PR TITLE
Fix lint-staged not working correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ And then configure `package.json` to look like this:
   "scripts": {
     "changelog": "uphold-scripts changelog $npm_package_version",
     "lint": "uphold-scripts lint",
+    "lint-staged": "lint-staged -q",
     "release": "uphold-scripts release",
     "test": "uphold-scripts test",
     "version": "uphold-scripts version"
   },
   "pre-commit": [
-    "lint-staged -q"
+    "lint-staged"
   ],
   "lint-staged": {
     "*.{js,mjs}": ["uphold-scripts lint"]

--- a/src/uphold-scripts-lint
+++ b/src/uphold-scripts-lint
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-eslint --cache . $@
+eslint --cache ${@:-.}


### PR DESCRIPTION
My manually testing done in #12 was wrong for some reason. This is the correct setup for the package.json.

`pre-commit` only runs scripts declared in `scripts` @ package.json.