### PR TITLE
Bump eslint-config-uphold to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@uphold/github-changelog-generator": "^3.0.0",
     "commander": "^8.3.0",
     "eslint": "~8.7.0",
-    "eslint-config-uphold": "^2.3.0",
+    "eslint-config-uphold": "^3.0.0",
     "jest": "^27.3.1",
     "lint-staged": "^12.3.4",
     "pre-commit": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1272,10 +1272,10 @@ eslint-config-prettier@^7.2.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz#f4a4bd2832e810e8cc7c1411ec85b3e85c0c53f9"
   integrity sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==
 
-eslint-config-uphold@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-uphold/-/eslint-config-uphold-2.3.0.tgz#d897bef94394b0c97a41ff1b4308aea4a7d2aacd"
-  integrity sha512-qjrK2O1Bu+qHAZUi5sQp6pFggn21D+ou/tVTL7fJtXg7LnmL9KqPAJGsnlXseMPxP5IBnXhLwgpqF7XiVqIp/A==
+eslint-config-uphold@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-uphold/-/eslint-config-uphold-3.0.0.tgz#4bd6ddc564585bcd75db072877621548b58563bc"
+  integrity sha512-XH3Kl4xEuin0lmwjx7L0UUfOdgxnmBLCclMU/Jcn/0DAZyGOzU+oj/bBYb4Bvoi7LQiHvmzH8FyWUEFWKqV4Cg==
   dependencies:
     "@babel/core" "^7.16.12"
     "@babel/eslint-parser" "^7.16.5"
@@ -1283,7 +1283,7 @@ eslint-config-uphold@^2.3.0:
     eslint-plugin-mocha "^5.3.0"
     eslint-plugin-prettier "^3.3.1"
     eslint-plugin-rulesdir "^0.1.0"
-    eslint-plugin-sort-imports-es6 "^0.0.3"
+    eslint-plugin-sort-imports-requires "^1.0.2"
     eslint-plugin-sql-template "^2.0.0"
 
 eslint-plugin-mocha@^5.3.0:
@@ -1305,10 +1305,13 @@ eslint-plugin-rulesdir@^0.1.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.1.0.tgz#ad144d7e98464fda82963eff3fab331aecb2bf08"
   integrity sha1-rRRNfphGT9qClj7/P6szGuyyvwg=
 
-eslint-plugin-sort-imports-es6@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-imports-es6/-/eslint-plugin-sort-imports-es6-0.0.3.tgz#959f391d459efbf971d3ebb696d79e1b567aeedc"
-  integrity sha1-lZ85HUWe+/lx0+u2lteeG1Z67tw=
+eslint-plugin-sort-imports-requires@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-imports-requires/-/eslint-plugin-sort-imports-requires-1.0.2.tgz#ba04fd40cd71da92d5d132b56f51da04916061d3"
+  integrity sha512-NVBvldKgVRrVQz+DFALAwcDUHUBF2fuZhWPrd7SylZvVeTyryaDGrL8lmm+xzaEw7tWz1HRLnk7REuVPwdvqZg==
+  dependencies:
+    eslint-utils "^3.0.0"
+    once "^1.4.0"
 
 eslint-plugin-sql-template@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This should be a major release, since people's projects will likely break on CI after upgrading. They will probably need to apply some fixes that the new eslint config will warn/error.