### PR TITLE
Lint all files when running lint script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ And then configure `package.json` to look like this:
 {
   "scripts": {
     "changelog": "uphold-scripts changelog $npm_package_version",
-    "lint": "uphold-scripts lint",
+    "lint": "uphold-scripts lint .",
     "lint-staged": "lint-staged -q",
     "release": "uphold-scripts release",
     "test": "uphold-scripts test",

--- a/src/uphold-scripts-lint
+++ b/src/uphold-scripts-lint
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-eslint --cache ${@:-.}
+eslint --cache $@


### PR DESCRIPTION
This makes it possible to run `yarn lint --fix` instead of `yarn lint . --fix`.