### PR TITLE
Disable credential persistence in release workflow checkout step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Setup Node.js version
       uses: actions/setup-node@v4


### PR DESCRIPTION
## Description

- Disable credential persistence during the checkout step of the release workflow.