### PR TITLE
Add `SKIP_NPM` input to release workflow for conditional NPM publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,11 @@ on:
         - patch
         default: minor
         required: true
+      SKIP_NPM:
+        description: 'Skip publishing to NPM?'
+        type: boolean
+        default: false
+        required: false
 
 jobs:
   release:
@@ -47,4 +52,4 @@ jobs:
         NPM_TOKEN: ${{ secrets.RELEASE_NPM_TOKEN }}
       run: |
         npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
-        npm run release --increment "${{ github.event.inputs.VERSION_BUMP }}" -V
+        npm run release --increment "${{ github.event.inputs.VERSION_BUMP }}" ${{ github.event.inputs.SKIP_NPM == true && '--no-npm' || '' }} -V


### PR DESCRIPTION
## Description

- Add a new input parameter, `SKIP_NPM` to the release workflow to allow skipping NPM publishing per release. This enhances flexibility during the release process.

See https://github.com/release-it/release-it/?tab=readme-ov-file#update-or-re-run-existing-releases