### PR TITLE
Update release workflow skip conditions for npm publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,14 +46,17 @@ jobs:
         git config user.email "bot@uphold.com"
         git config --global url.https://${{ secrets.RELEASE_GITHUB_TOKEN }}@github.com/.insteadOf https://github.com/
 
-    - name: Generate release
+    - name: Configure npm
+      run: npm config set //registry.npmjs.org/:_authToken ${{ secrets.RELEASE_NPM_TOKEN }}
+
+    - name: Generate release and publish to npm
       env:
         GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.RELEASE_NPM_TOKEN }}
-      run: |
-        npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
-        if [ "${{ github.event.inputs.SKIP_NPM }}" = "true" ]; then
-          npm run release --increment "${{ github.event.inputs.VERSION_BUMP }}" --no-npm -V
-        else
-          npm run release --increment "${{ github.event.inputs.VERSION_BUMP }}" -V
-        fi
+      if: ${{ github.event.inputs.SKIP_NPM == 'false' }}
+      run: npm run release --increment "${{ github.event.inputs.VERSION_BUMP }}" -V
+
+    - name: Generate release without publishing to npm
+      env:
+        GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+      if: ${{ github.event.inputs.SKIP_NPM == 'true' }}
+      run: npm run release --increment "${{ github.event.inputs.VERSION_BUMP }}" -V -- --no-npm


### PR DESCRIPTION
## Description

- Refine the release workflow to conditionally handle npm publishing based on the `SKIP_NPM` input.
- Move `npm config` to a workflow step.